### PR TITLE
Fix crash when $.uniform.update(), and fix button clickable though invisible

### DIFF
--- a/jquery.uniform.js
+++ b/jquery.uniform.js
@@ -622,7 +622,7 @@ Enjoy!
           }else{
             divTag.removeClass(options.disabledClass);
           }
-        }else if($e.is(":submit") || $e.is(":reset") || $e.is("button") || $e.is("a") || elem.is("input[type=button]")){
+        }else if($e.is(":submit") || $e.is(":reset") || $e.is("button") || $e.is("a") || $e.is("input[type=button]")){
           var divTag = $e.closest("div");
           divTag.removeClass(options.hoverClass+" "+options.focusClass+" "+options.activeClass);
           


### PR DESCRIPTION
Two small changes.

1) On my page, my `input[type=button]`s are fairly wide, and `{opacity:0}` being set means they can still be triggered if I click a hundred pixels or so to the right.
This is bad, as the right-most is a "delete" button.  Good thing I noticed it before I put it up on the production server.  Changing this to `{display:none}` Works On My Machine™ on Chrome and Firefox - have not (yet) tested  elsewhere, but it should work fine, as that's the normal way to completely hide a control.

2) Also on my page, if I attempt to `$.uniform.update()` after `$("select, input, textarea").uniform()`, I get a crash at the other line changed.  I have no idea why that line includes `elem.is("input[type=button]")`, but it shouldn't, as elem is the entire collection at that point.  Changed to match the rest of the checks, which are `$e.is...` which solves this.
