### PR TITLE
Patch for jQuery 1.6 compatibility

### DIFF
--- a/jquery.uniform.js
+++ b/jquery.uniform.js
@@ -643,7 +643,7 @@ Enjoy!
 
         if(elem.is("select")){
           //element is a select
-          if(elem.is(":multiple") != true){
+          if(!this.multiple){
             //element is not a multi-select
             if(elem.attr("size") == undefined || elem.attr("size") <= 1){
               doSelect(elem);


### PR DESCRIPTION
Updated for compatibility with jQuery 1.6. Boolean attributes need to be handled differently -- eg, .is(":checked") instead of .attr("checked") (which may return ""). The .is(":checked") syntax should also be compatible with earlier versions.
