### PR TITLE
Update check for id for compatibility with jQuery 1.6+

### DIFF
--- a/jquery.uniform.js
+++ b/jquery.uniform.js
@@ -85,7 +85,7 @@ Enjoy!
       
       divTag.addClass(options.buttonClass);
       
-      if(options.useID && $el.attr("id") != "") divTag.attr("id", options.idPrefix+"-"+$el.attr("id"));
+      if(options.useID && $el.attr("id")) divTag.attr("id", options.idPrefix+"-"+$el.attr("id"));
       
       var btnText;
       
@@ -162,7 +162,7 @@ Enjoy!
 
       divTag.addClass(options.selectClass);
 
-      if(options.useID && elem.attr("id") != ""){
+      if(options.useID && elem.attr("id")){
         divTag.attr("id", options.idPrefix+"-"+elem.attr("id"));
       }
       
@@ -237,7 +237,7 @@ Enjoy!
       divTag.addClass(options.checkboxClass);
 
       //assign the id of the element
-      if(options.useID && elem.attr("id") != ""){
+      if(options.useID && elem.attr("id")){
         divTag.attr("id", options.idPrefix+"-"+elem.attr("id"));
       }
 
@@ -310,7 +310,7 @@ Enjoy!
 
       divTag.addClass(options.radioClass);
 
-      if(options.useID && elem.attr("id") != ""){
+      if(options.useID && elem.attr("id")){
         divTag.attr("id", options.idPrefix+"-"+elem.attr("id"));
       }
 
@@ -391,7 +391,7 @@ Enjoy!
       filenameTag.addClass(options.filenameClass);
       btnTag.addClass(options.fileBtnClass);
 
-      if(options.useID && $el.attr("id") != ""){
+      if(options.useID && $el.attr("id")){
         divTag.attr("id", options.idPrefix+"-"+$el.attr("id"));
       }
 


### PR DESCRIPTION
Before jQuery 1.6, $el.attr('id') returned "" if there was no id attribute, but starting with jQuery it returns undefined. So the check $el.attr('id') != "" no longer works. Thus if you have form controls with no id, you end up with a bunch of elements with the duplicated id "uniform-undefined".

Since id is always a string, and since string "0" is true in boolean context, the check can simply use $el.attr('id') alone, since both "" and undefined are false.
