### PR TITLE
Checkbox checked state handling when by default its checked

### DIFF
--- a/jquery.uniform.js
+++ b/jquery.uniform.js
@@ -304,6 +304,7 @@ Enjoy!
       
       //handle defaults
       if($(elem).attr("checked")){
+        $(elem).attr("checked", "checked"); // helpful when its by-default checked
         //box is checked by default, check our box
         spanTag.addClass(options.checkedClass);
       }


### PR DESCRIPTION
The patch will fix the issue when a checkbox is by default checked and clicking it does not remove the span's class checked.
