### PR TITLE
Using .text instead of .html for text insertion from selected select value to spans. 

### DIFF
--- a/jquery.uniform.js
+++ b/jquery.uniform.js
@@ -182,7 +182,7 @@ Enjoy!
 
       elem.bind({
         "change.uniform": function() {
-          spanTag.text(elem.find(":selected").html());
+          spanTag.text(elem.find(":selected").text());
           divTag.removeClass(options.activeClass);
         },
         "focus.uniform": function() {
@@ -209,7 +209,7 @@ Enjoy!
           divTag.removeClass(options.activeClass);
         },
         "keyup.uniform": function(){
-          spanTag.text(elem.find(":selected").html());
+          spanTag.text(elem.find(":selected").text());
         }
       });
       


### PR DESCRIPTION
Changed the insertion of text into the spans that hold the values of selects from having html inserted to having text inserted. I was running into an issue where I had encoded ampersands '&amp;' in my select values that in turn was being interpreted literally as eg. 'Dogs &amp; cats' because of the use of element.html instead of element.text.
