### PR TITLE
Changed checkbox onclick check, from .attr("checked") to .is(':checked')

### DIFF
--- a/jquery.uniform.js
+++ b/jquery.uniform.js
@@ -260,7 +260,7 @@ Enjoy!
           divTag.removeClass(options.focusClass);
         },
         "click.uniform touchend.uniform": function(){
-          if(!$(elem).attr("checked")){
+          if(!$(elem).is(':checked')){
             //box was just unchecked, uncheck span
             spanTag.removeClass(options.checkedClass);
           }else{


### PR DESCRIPTION
Using `$(elem).attr("checked")` doesn't seem to be reliable on WebKit (tested with Chrome 18/Win); it doesn't work most of the time in our project. Switching to `$(elem).is(':checked')` seems to work reliably. 
