### PR TITLE
opacity=0 not opacity:0 in uniform.default.css

### DIFF
--- a/css/uniform.default.css
+++ b/css/uniform.default.css
@@ -525,7 +525,7 @@ div.selector span {
 div.selector select {
   position: absolute;
   opacity: 0;
-  filter: alpha(opacity:0);
+  filter: alpha(opacity=0);
   height: 25px;
   border: none;
   background: none;
@@ -545,7 +545,7 @@ div.checker span {
 
 div.checker input {
   opacity: 0;
-  filter: alpha(opacity:0);
+  filter: alpha(opacity=0);
   display: inline-block;
   background: none;
 }
@@ -564,7 +564,7 @@ div.radio span {
 
 div.radio input {
   opacity: 0;
-  filter: alpha(opacity:0);
+  filter: alpha(opacity=0);
   text-align: center;
   display: inline-block;
   background: none;
@@ -598,7 +598,7 @@ div.uploader span.filename {
 
 div.uploader input {
   opacity: 0;
-  filter: alpha(opacity:0);
+  filter: alpha(opacity=0);
   position: absolute;
   top: 0;
   right: 0;


### PR DESCRIPTION
This is a bug fix (rake:assets:precompile fails in production without this fix). Cool library!
