### PR TITLE
fix css  filter: alpha(opacity=0)

### DIFF
--- a/css/uniform.default.css
+++ b/css/uniform.default.css
@@ -525,7 +525,8 @@ div.selector span {
 div.selector select {
   position: absolute;
   opacity: 0;
-  filter: alpha(opacity:0);
+  filter: alpha(opacity=0); /* use '=' here, not ':' */
+  -moz-opacity: 0;
   height: 25px;
   border: none;
   background: none;
@@ -545,7 +546,8 @@ div.checker span {
 
 div.checker input {
   opacity: 0;
-  filter: alpha(opacity:0);
+  filter: alpha(opacity=0);
+  -moz-opacity: 0;
   display: inline-block;
   background: none;
 }
@@ -564,7 +566,8 @@ div.radio span {
 
 div.radio input {
   opacity: 0;
-  filter: alpha(opacity:0);
+  filter: alpha(opacity=0);
+  -moz-opacity: 0;
   text-align: center;
   display: inline-block;
   background: none;
@@ -598,7 +601,8 @@ div.uploader span.filename {
 
 div.uploader input {
   opacity: 0;
-  filter: alpha(opacity:0);
+  filter: alpha(opacity=0);
+  -moz-opacity: 0;
   position: absolute;
   top: 0;
   right: 0;


### PR DESCRIPTION
When I try build my Rails 3.2 project, I get error:
Invalid CSS after "...: alpha(opacity": expected comma, was ":0);"

To fix this error I change this line in css:
 filter: alpha(opacity=0); /\* use '=' here, not ':' */
