### PR TITLE
Update jquery.uniform.js

### DIFF
--- a/jquery.uniform.js
+++ b/jquery.uniform.js
@@ -199,6 +199,10 @@ Enjoy!
           divTag.removeClass(options.activeClass);
         },
         "click.uniform touchend.uniform": function(){
+          //Fix For ie8 and ie7
+          if(spanTag.html() != elem.find(":selected").html()){
+            spanTag.html(elem.find(":selected").html());
+          }
           divTag.removeClass(options.activeClass);
         },
         "mouseenter.uniform": function() {


### PR DESCRIPTION
I have noticed that in some cases, while selecting with select boxes, ie7 and ie8 wouldn't take the value. 
So by testing on the click event, we can make one last check on the selected value and compare it with the "span". 
