### PR TITLE
jQuery 1.9.x support

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 	<head>
+
+        <script src="http://modernizr.com/downloads/modernizr-latest.js"></script>
 		<script type="text/javascript" charset="utf-8">
 /*global optionValues*/
 (function () {
@@ -69,7 +71,7 @@ $(function () {
 
 	// Debugging code to check for multiple click events
 	$selects = $("select").click(function () {
-		if (typeof console !== undefined && typeof console.log !== undefined) {
+		if (typeof console !== "undefined" && typeof console.log !== "undefined") {
 			console.log($(this).attr('id') + " clicked");
 		}
 	});
@@ -154,6 +156,7 @@ $(function () {
 				<option value="1.6">jQuery 1.6.x</option>
 				<option value="1.7">jQuery 1.7.x</option>
 				<option value="1.8">jQuery 1.8.x</option>
+                <option value="1.9.0">jQuery 1.9.x</option>
 			</select>
 			<span id="jqueryCurrentVersion"></span>
 			<button id="remove">Remove</button>

--- a/jquery.uniform.js
+++ b/jquery.uniform.js
@@ -420,6 +420,18 @@ Enjoy!
 		}
 	}
 
+    function browserSupport() {
+        if (typeof $.browser != "undefined") {
+            return true;
+        } else {
+            if (typeof Modernizr == "undefined") {
+                alert('Modernizr should be loaded because browser support was removed in your jquery version (1.9+).');
+            }
+
+            return false;
+        }
+    }
+
 
 	/**
 	 * The browser doesn't provide sizes of elements that are not visible.
@@ -436,7 +448,6 @@ Enjoy!
 		}, callback);
 	}
 
-
 	/**
 	 * Standard way to unwrap the div/span combination from an element
 	 *
@@ -452,6 +463,7 @@ Enjoy!
 
 	var allowStyling = true,  // False if IE6 or other unsupported browsers
 		highContrastTest = false,  // Was the high contrast test ran?
+        browserSupport = browserSupport(), // does jquery support browser
 		uniformHandlers = [  // Objects that take care of "unification"
 			{
 				// Buttons
@@ -609,7 +621,7 @@ Enjoy!
 					filenameUpdate();
 
 					// IE7 doesn't fire onChange until blur or second fire.
-					if ($.browser.msie) {
+					if (browserSupport && $.browser.msie) {
 						// IE considers browser chrome blocking I/O, so it
 						// suspends tiemouts until after the file has
 						// been selected.
@@ -622,7 +634,10 @@ Enjoy!
 					} else {
 						// All other browsers behave properly
 						bindMany($el, options, {
-							change: filenameUpdate
+							change: function() {
+                                alert('I change');
+                                filenameUpdate();
+                            }
 						});
 					}
 
@@ -826,7 +841,7 @@ Enjoy!
 		];
 
 	// IE6 can't be styled - can't set opacity on select
-	if ($.browser.msie && $.browser.version < 7) {
+	if ((browserSupport && $.browser.msie && $.browser.version < 7) || (!browserSupport && !Modernizr.opacity)) {
 		allowStyling = false;
 	}
 


### PR DESCRIPTION
Support for jQuery 1.9.x. I've added modernizr support because jquery removed $.browser. It will produce an error when modernizr is not loaded and needed, for older jquery files, nothing changed.

I also removed the old bind code because it worked fine in IE7 (or I didn't test it how it should)
