### PR TITLE
Add compatibility with jQuery 2 and up in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
         "dist/js/jquery.uniform.standalone.js"
     ],
     "dependencies": {
-        "jquery": "^1.6"
+        "jquery": ">=1.6"
     },
     "moduleType": [
         "globals"


### PR DESCRIPTION
Fix the fact that this plugin should work with jQuery 1.6+, but the bower.json claims that it only works in versions between >=1.6 & < 2.0.
